### PR TITLE
Ensure GitHub detects all .fs files as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.fs linguist-language=Forth


### PR DESCRIPTION
Hello,

GitHub mistakenly believes some of your `.fs` files are written in GLSL.  This adds some metadata to fix that.

Best regards,
Lars Brinkhoff